### PR TITLE
Edits

### DIFF
--- a/templates/quickstart-hashicorp-consul-master.template
+++ b/templates/quickstart-hashicorp-consul-master.template
@@ -24,16 +24,16 @@ Metadata:
           - ConsulClientNodes
           - KeyPairName
       - Label:
-          default: AWS Quick Start configuration
-        Parameters:
-          - QSS3BucketName
-          - QSS3KeyPrefix
-      - Label:
           default: "DNS and SSL configuration"
         Parameters:
           - LoadBalancerFQDN
           - HostedZoneID
           - SSLCertificateArn
+      - Label:
+          default: AWS Quick Start configuration
+        Parameters:
+          - QSS3BucketName
+          - QSS3KeyPrefix
     ParameterLabels:
       AccessCIDR:
         default: Permitted IP range

--- a/templates/quickstart-hashicorp-consul.template
+++ b/templates/quickstart-hashicorp-consul.template
@@ -16,6 +16,10 @@ Metadata:
           - PublicSubnet2ID
           - PublicSubnet3ID
       - Label:
+          default: "Bastion host configuration"
+        Parameters:
+          - BastionSecurityGroupID
+      - Label:
           default: Consul Setup
         Parameters:
           - ConsulInstanceType
@@ -25,20 +29,16 @@ Metadata:
           - ConsulEc2RetryTagValue
           - KeyPair
       - Label:
-          default: AWS Quick Start configuration
-        Parameters:
-          - QSS3BucketName
-          - QSS3KeyPrefix
-      - Label:
           default: "DNS and SSL configuration"
         Parameters:
           - LoadBalancerFQDN
           - HostedZoneID
           - SSLCertificateArn
       - Label:
-          default: "Bastion host configuration"
+          default: AWS Quick Start configuration
         Parameters:
-          - BastionSecurityGroupID
+          - QSS3BucketName
+          - QSS3KeyPrefix
     ParameterLabels:
       KeyPair:
         default: Key name
@@ -82,7 +82,7 @@ Metadata:
         default: Bastion host security group ID
 Parameters:
   BastionSecurityGroupID:
-    Description: ID of the bastion host security group to enable SSH connections (e.g. sg-7f16e910)
+    Description: ID of the bastion host security group to enable SSH connections (e.g., sg-7f16e910)
     Type: "AWS::EC2::SecurityGroup::Id"
   ConsulInstanceType:
     Type: String


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Moved Quick Start category to the end, per the Contributor's Guide, for both the master and workload templates. Also, in the workload template, moved the new Bastion host configuration category up so that it immediately follows the VPC Network configuration category.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
